### PR TITLE
Escape table name to allow for keywords conflict

### DIFF
--- a/sas2db/run.py
+++ b/sas2db/run.py
@@ -27,7 +27,7 @@ def get_args():
 
 
 def row_count(con, table):
-    result = con.execute('SELECT COUNT(*) FROM ' + table)
+    result = con.execute('SELECT COUNT(*) FROM ' + repr(table))
     return result.fetchone()[0]
 
 


### PR DESCRIPTION
### Example
```bash
$ sas2db --db is.db --table is ~/Downloads/is.sas7bdat
Writing to is.db in sqlite using pysqlite...                                                                        
Writing to is table...                                                                                              
Traceback (most recent call last):                                                                                  
  File "/Users/***/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 1772, in _execute_context
    cursor, statement, parameters, context                                                                          
  File "/Users/***/lib/python3.7/site-packages/sqlalchemy/engine/default.py", line 717, in do_execute
    cursor.execute(statement, parameters)                                                                           
sqlite3.OperationalError: near "is": syntax error
```

### With the fix
```
Writing to is.db in sqlite using pysqlite...
Writing to is table...
Wrote *** rows.
```